### PR TITLE
Initialize coordinator during setup entry

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,15 @@
+name: tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: devcontainers/ci@v0.3
+        with:
+          runCmd: |
+            python -m pytest -q

--- a/custom_components/ail/__init__.py
+++ b/custom_components/ail/__init__.py
@@ -48,6 +48,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     client = AILEnergyClient(entry.data["username"], entry.data["password"])
     data_coordinator = EnergyDataUpdateCoordinator(hass, entry, client)
 
+    # Run coordinator setup (historical fetch when needed)
+    await data_coordinator.async_setup()
+
     # Get initial data
     await data_coordinator.async_config_entry_first_refresh()
 

--- a/custom_components/ail/coordinator.py
+++ b/custom_components/ail/coordinator.py
@@ -126,6 +126,10 @@ class EnergyDataUpdateCoordinator(DataUpdateCoordinator[Optional[ConsumptionData
         else:
             _LOGGER.info("Statistics already exist, skipping historical data fetch")
 
+    async def async_setup(self) -> None:
+        """Public setup hook for initial coordinator preparation."""
+        await self._async_setup()
+
     async def _fetch_chunked_data(
         self, start_date: datetime, end_date: datetime
     ) -> Dict[datetime, ConsumptionData]:

--- a/custom_components/tests/test_init.py
+++ b/custom_components/tests/test_init.py
@@ -1,12 +1,76 @@
 """Test component setup."""
 
-from homeassistant.setup import async_setup_component
+from unittest.mock import AsyncMock, patch
 
-from custom_components.ail.const import DOMAIN
+from homeassistant.setup import async_setup_component
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.ail.const import DOMAIN, ENERGY_CONSUMPTION_KEY
 
 from custom_components.tests.conftest import auto_enable_custom_integrations  # noqa: F401
+
+
+class _DummyRecorder:
+    async def async_add_executor_job(self, func, *args):
+        return func(*args)
 
 
 async def test_async_setup(hass):
     """Test the component gets setup."""
     assert await async_setup_component(hass, DOMAIN, {}) is True
+
+
+async def test_async_setup_entry_fetches_history_when_no_stats(hass):
+    """Ensure historical data fetch runs when no stats exist."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"username": "user@example.com", "password": "secret"},
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ail.api_client.AILEnergyClient.login", return_value=True
+    ), patch(
+        "custom_components.ail.coordinator.EnergyDataUpdateCoordinator._fetch_chunked_data",
+        return_value={},
+    ), patch(
+        "custom_components.ail.coordinator.get_instance",
+        return_value=_DummyRecorder(),
+    ), patch(
+        "custom_components.ail.coordinator.get_last_statistics",
+        return_value={},
+    ), patch(
+        "custom_components.ail.coordinator.EnergyDataUpdateCoordinator._fetch_historical_data",
+        new=AsyncMock(),
+    ) as fetch_history:
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        fetch_history.assert_awaited()
+
+
+async def test_async_setup_entry_skips_history_when_stats_exist(hass):
+    """Ensure historical fetch is skipped when stats exist."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"username": "user@example.com", "password": "secret"},
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ail.api_client.AILEnergyClient.login", return_value=True
+    ), patch(
+        "custom_components.ail.coordinator.EnergyDataUpdateCoordinator._fetch_chunked_data",
+        return_value={},
+    ), patch(
+        "custom_components.ail.coordinator.get_instance",
+        return_value=_DummyRecorder(),
+    ), patch(
+        "custom_components.ail.coordinator.get_last_statistics",
+        return_value={ENERGY_CONSUMPTION_KEY: [{"start": 0, "sum": 0.0}]},
+    ), patch(
+        "custom_components.ail.coordinator.EnergyDataUpdateCoordinator._fetch_historical_data",
+        new=AsyncMock(),
+    ) as fetch_history:
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        fetch_history.assert_not_awaited()

--- a/scripts/setup
+++ b/scripts/setup
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python -m pip install --upgrade pip
+python -m pip install -r requirements_test.txt


### PR DESCRIPTION
Summary
- ensure the energy coordinator performs its preparation work during entry setup, which may trigger historical data fetches when required
- add tests covering both the historical fetch path and the skip path based on existing statistics

Testing
- Not run (not requested)