### PR TITLE
Harden AIL API client lifecycle

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
             cache: "pip"
 
         - name: "Install requirements"
-          run: python3 -m pip install -r requirements.txt
+          run: python3 -m pip install -r requirements_dev.txt
 
         - name: "Lint"
           run: python3 -m ruff check .

--- a/custom_components/ail/__init__.py
+++ b/custom_components/ail/__init__.py
@@ -66,7 +66,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
+        coordinator = hass.data[DOMAIN].pop(entry.entry_id)
+        await coordinator.api_client.close()
     return unload_ok
 
 

--- a/custom_components/ail/api_client.py
+++ b/custom_components/ail/api_client.py
@@ -35,7 +35,7 @@ class AILEnergyClient:
         self.email = email
         self.password = password
         self.token = None
-        self.meter_id = None
+        self._meter_id = None
         self.session = None
         self._headers = {
             "Cache-Control": "no-cache, max-age=0, must-revalidate",
@@ -48,8 +48,12 @@ class AILEnergyClient:
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self.close()
+
+    async def close(self) -> None:
         if self.session:
             await self.session.close()
+            self.session = None
 
     async def login(self) -> bool:
         if not self.session:
@@ -79,15 +83,15 @@ class AILEnergyClient:
 
                 meter_match = re.search(r'"ID":\s*(\d+)', content)
                 if meter_match:
-                    self.meter_id = meter_match.group(1)
+                    self._meter_id = meter_match.group(1)
 
-                if self.token and self.meter_id:
+                if self.token and self._meter_id:
                     return True
 
             return False
 
-    def meter_id(self) -> Optional[str]:
-        return self.meter_id
+    def get_meter_id(self) -> Optional[str]:
+        return self._meter_id
 
     async def get_consumption_data(
         self, _from: datetime, _to: datetime
@@ -98,7 +102,7 @@ class AILEnergyClient:
             raise ValueError("Not logged in. Call login() first")
 
         payload = {
-            "meterID": self.meter_id,
+            "meterID": self._meter_id,
             "scale": "hours",
             "timeFrame": {
                 "from": _from.strftime("%Y-%m-%d %H:%M:%S"),

--- a/custom_components/ail/config_flow.py
+++ b/custom_components/ail/config_flow.py
@@ -136,8 +136,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def _test_credentials(self, user_input):
         """Test if we can authenticate with the credentials."""
         client = AILEnergyClient(user_input[CONF_USERNAME], user_input[CONF_PASSWORD])
-        if not await client.login():
-            raise InvalidAuth()
+        try:
+            if not await client.login():
+                raise InvalidAuth()
+        finally:
+            await client.close()
 
 
 class CannotConnect(HomeAssistantError):

--- a/custom_components/tests/test_config_flow.py
+++ b/custom_components/tests/test_config_flow.py
@@ -1,0 +1,47 @@
+"""Tests for config flow."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from custom_components.ail.config_flow import ConfigFlow, InvalidAuth
+from custom_components.ail.const import CONF_PASSWORD, CONF_USERNAME, DOMAIN
+
+
+@pytest.mark.asyncio
+async def test_test_credentials_closes_client_on_success(hass):
+    """Ensure config flow closes the client after successful login."""
+    flow = ConfigFlow()
+    flow.hass = hass
+
+    with patch(
+        "custom_components.ail.config_flow.AILEnergyClient.login",
+        new=AsyncMock(return_value=True),
+    ), patch(
+        "custom_components.ail.config_flow.AILEnergyClient.close",
+        new=AsyncMock(),
+    ) as close_client:
+        await flow._test_credentials(
+            {CONF_USERNAME: "user@example.com", CONF_PASSWORD: "secret"}
+        )
+        close_client.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_test_credentials_closes_client_on_invalid_auth(hass):
+    """Ensure config flow closes the client when auth fails."""
+    flow = ConfigFlow()
+    flow.hass = hass
+
+    with patch(
+        "custom_components.ail.config_flow.AILEnergyClient.login",
+        new=AsyncMock(return_value=False),
+    ), patch(
+        "custom_components.ail.config_flow.AILEnergyClient.close",
+        new=AsyncMock(),
+    ) as close_client:
+        with pytest.raises(InvalidAuth):
+            await flow._test_credentials(
+                {CONF_USERNAME: "user@example.com", CONF_PASSWORD: "wrong"}
+            )
+        close_client.assert_awaited()

--- a/custom_components/tests/test_init.py
+++ b/custom_components/tests/test_init.py
@@ -74,3 +74,34 @@ async def test_async_setup_entry_skips_history_when_stats_exist(hass):
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
         fetch_history.assert_not_awaited()
+
+
+async def test_async_unload_entry_closes_client(hass):
+    """Ensure unloading an entry closes the API client session."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"username": "user@example.com", "password": "secret"},
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ail.api_client.AILEnergyClient.login", return_value=True
+    ), patch(
+        "custom_components.ail.coordinator.EnergyDataUpdateCoordinator._fetch_chunked_data",
+        return_value={},
+    ), patch(
+        "custom_components.ail.coordinator.get_instance",
+        return_value=_DummyRecorder(),
+    ), patch(
+        "custom_components.ail.coordinator.get_last_statistics",
+        return_value={},
+    ), patch(
+        "custom_components.ail.api_client.AILEnergyClient.close",
+        new=AsyncMock(),
+    ) as close_client:
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+        close_client.assert_awaited()


### PR DESCRIPTION
Summary
- close `AILEnergyClient` sessions explicitly (unload cleanup, async context, and new `close` helper)
- store meter ID on a private attribute, expose via `get_meter_id`, and use it consistently
- ensure config flow cleans up clients after credential checks to avoid leaks

Testing
- Not run (not requested)