### PR TITLE
Use timezone helpers for consumption statistics

### DIFF
--- a/custom_components/ail/coordinator.py
+++ b/custom_components/ail/coordinator.py
@@ -14,6 +14,7 @@ from homeassistant.const import UnitOfEnergy
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.util import dt as dt_util
 
 from .api_client import AILEnergyClient, ConsumptionResponse
 from .const import (
@@ -168,7 +169,7 @@ class EnergyDataUpdateCoordinator(DataUpdateCoordinator[Optional[ConsumptionData
         if not await self.api_client.login():
             raise ConfigEntryAuthFailed
 
-        end_date = datetime.now()
+        end_date = dt_util.now()
         start_date = end_date - timedelta(days=CONSUMPTION_DATA_DAYS_TO_FETCH)
         all_consumption_data = await self._fetch_chunked_data(start_date, end_date)
 
@@ -190,7 +191,7 @@ class EnergyDataUpdateCoordinator(DataUpdateCoordinator[Optional[ConsumptionData
         Raises:
             ConfigEntryAuthFailed: If authentication fails
         """
-        end_date = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+        end_date = dt_util.now().replace(hour=0, minute=0, second=0, microsecond=0)
         start_date = end_date - timedelta(days=90)  # last 3 months
 
         if not await self.api_client.login():
@@ -224,7 +225,8 @@ class EnergyDataUpdateCoordinator(DataUpdateCoordinator[Optional[ConsumptionData
         hourly_sums: Dict[datetime, ConsumptionData] = {}
         use_fixed_tariff, _, _ = self._get_tariff_settings()
         for consumption in consumptions:
-            hour_key = consumption.from_date.replace(minute=0, second=0, microsecond=0)
+            local_from = self._as_local(consumption.from_date)
+            hour_key = local_from.replace(minute=0, second=0, microsecond=0)
             if hour_key not in hourly_sums:
                 hourly_sums[hour_key] = ConsumptionData(
                     from_date=hour_key,
@@ -239,7 +241,7 @@ class EnergyDataUpdateCoordinator(DataUpdateCoordinator[Optional[ConsumptionData
                 # https://www.ail.ch/privati/elettricita/servizi/tariffe.html
                 # between 22:00 and 06:00 is considered night (off-peak hours)
                 # between 06:00 and 22:00 is considered day (peak hours)
-                if 22 <= current.from_date.hour or current.from_date.hour < 6:
+                if 22 <= hour_key.hour or hour_key.hour < 6:
                     current.night += consumption.day
                 else:
                     current.day += consumption.day
@@ -358,7 +360,7 @@ class EnergyDataUpdateCoordinator(DataUpdateCoordinator[Optional[ConsumptionData
             sum_value += value
             statistics.append(
                 StatisticData(
-                    start=hour,
+                    start=dt_util.as_utc(hour),
                     state=value,
                     sum=sum_value,
                 )
@@ -408,3 +410,10 @@ class EnergyDataUpdateCoordinator(DataUpdateCoordinator[Optional[ConsumptionData
             )
         )
         return fixed_tariff, peak_price, off_peak_price
+
+    @staticmethod
+    def _as_local(value: datetime) -> datetime:
+        """Ensure datetime is timezone-aware and in local time."""
+        if value.tzinfo is None or value.tzinfo.utcoffset(value) is None:
+            return value.replace(tzinfo=dt_util.DEFAULT_TIME_ZONE)
+        return dt_util.as_local(value)

--- a/custom_components/ail/sensor.py
+++ b/custom_components/ail/sensor.py
@@ -15,6 +15,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
 
 from custom_components.ail import DOMAIN
 from custom_components.ail.const import DAILY_PRICE_CHF, NIGHTLY_PRICE_CHF
@@ -73,7 +74,7 @@ SENSORS: tuple[EnergyEntityDescription, ...] = (
         suggested_display_precision=3,
         entity_registry_enabled_default=False,
         value_fn=lambda data: DAILY_PRICE_CHF
-        if 6 <= data.from_date.hour < 22
+        if 6 <= dt_util.as_local(data.from_date).hour < 22
         else NIGHTLY_PRICE_CHF,
     ),
 )

--- a/custom_components/tests/test_timezone.py
+++ b/custom_components/tests/test_timezone.py
@@ -1,0 +1,115 @@
+"""Tests for timezone handling."""
+
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant.util import dt as dt_util
+
+from custom_components.ail.api_client import AILEnergyClient
+from custom_components.ail.const import DOMAIN
+from custom_components.ail.coordinator import ConsumptionData, EnergyDataUpdateCoordinator
+
+
+class _DummyRecorder:
+    async def async_add_executor_job(self, func, *args):
+        return func(*args)
+
+
+def _make_coordinator(hass):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"username": "user@example.com", "password": "secret"},
+    )
+    entry.add_to_hass(hass)
+    return EnergyDataUpdateCoordinator(hass, entry, AILEnergyClient("u", "p"))
+
+
+def test_sum_hourly_consumptions_uses_local_time(hass):
+    """Naive datetimes should be treated as local for day/night bucketing."""
+    tz = dt_util.get_time_zone("Europe/Zurich")
+    dt_util.set_default_time_zone(tz)
+    try:
+        coordinator = _make_coordinator(hass)
+
+        # 23:15 local should be night; 12:10 local should be day
+        night_base = datetime(2024, 1, 1, 23, 15, 0)
+        day_base = datetime(2024, 1, 2, 12, 10, 0)
+
+        consumptions = []
+        for _ in range(4):
+            consumptions.append(
+                ConsumptionData(
+                    from_date=night_base,
+                    to_date=night_base + timedelta(hours=1),
+                    day=1.0,
+                )
+            )
+            consumptions.append(
+                ConsumptionData(
+                    from_date=day_base,
+                    to_date=day_base + timedelta(hours=1),
+                    day=2.0,
+                )
+            )
+
+        hourly = coordinator._sum_hourly_consumptions(consumptions)
+
+        night_key = dt_util.as_local(night_base).replace(
+            minute=0, second=0, microsecond=0
+        )
+        day_key = dt_util.as_local(day_base).replace(minute=0, second=0, microsecond=0)
+
+        assert night_key in hourly
+        assert day_key in hourly
+        assert hourly[night_key].night == 4.0
+        assert hourly[night_key].day == 0.0
+        assert hourly[day_key].day == 8.0
+        assert hourly[day_key].night == 0.0
+    finally:
+        dt_util.set_default_time_zone(dt_util.UTC)
+
+
+@pytest.mark.asyncio
+async def test_insert_statistics_uses_utc_start(hass):
+    """Statistic start timestamps should be stored in UTC."""
+    tz = dt_util.get_time_zone("Europe/Zurich")
+    dt_util.set_default_time_zone(tz)
+    try:
+        coordinator = _make_coordinator(hass)
+        local_hour = dt_util.now().replace(minute=0, second=0, microsecond=0)
+        consumptions = {
+            local_hour: ConsumptionData(
+                from_date=local_hour,
+                to_date=local_hour + timedelta(hours=1),
+                day=1.0,
+            )
+        }
+        captured = {}
+
+        def _capture_stats(_hass, _metadata, statistics):
+            captured["stats"] = statistics
+
+        with patch(
+            "custom_components.ail.coordinator.get_last_statistics", return_value={}
+        ), patch(
+            "custom_components.ail.coordinator.get_instance",
+            return_value=_DummyRecorder(),
+        ), patch(
+            "custom_components.ail.coordinator.async_add_external_statistics",
+            new=_capture_stats,
+        ):
+            await coordinator._insert_statistic_type(
+                consumptions,
+                "day",
+                "test:stat",
+                "Test stat",
+                metadata={"unit_of_measurement": None},
+            )
+
+        assert "stats" in captured
+        assert captured["stats"][0]["start"].tzinfo == dt_util.UTC
+    finally:
+        dt_util.set_default_time_zone(dt_util.UTC)


### PR DESCRIPTION
Summary:
- replace naive `datetime.now()` and manual hour arithmetic in `coordinator.py` with `dt_util` helpers, making hour bucketing and statistics use timezone-aware dates
- adjust the sensor to rely on the localized hour for day/night pricing
- add regression tests for local bucketing and UTC statistic timestamps

Testing:
- Not run (not requested)