### PR TITLE
Prevent duplicate AIL account configs

### DIFF
--- a/custom_components/ail/config_flow.py
+++ b/custom_components/ail/config_flow.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.data_entry_flow import FlowResult
+from homeassistant.data_entry_flow import AbortFlow, FlowResult
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import selector
 
@@ -31,7 +33,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.auth_data = None
 
     async def async_step_user(
-        self, user_input: dict[str, any] | None = None
+        self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle the initial step."""
         errors = {}
@@ -54,6 +56,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             try:
+                await self.async_set_unique_id(
+                    user_input[CONF_USERNAME].strip().lower()
+                )
+                self._abort_if_unique_id_configured()
+
                 # Validate the credentials here if possible
                 await self._test_credentials(user_input)
 
@@ -65,6 +72,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "cannot_connect"
             except InvalidAuth:
                 errors["base"] = "invalid_auth"
+            except AbortFlow:
+                raise
             except Exception:  # pylint: disable=broad-except
                 errors["base"] = "unknown"
 
@@ -79,7 +88,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
     async def async_step_tariff(
-        self, user_input: dict[str, any] | None = None
+        self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle the tariff configuration step."""
         errors = {}

--- a/custom_components/ail/config_flow.py
+++ b/custom_components/ail/config_flow.py
@@ -56,9 +56,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             try:
-                await self.async_set_unique_id(
-                    user_input[CONF_USERNAME].strip().lower()
-                )
+                normalized_username = user_input[CONF_USERNAME].strip().lower()
+                if self._is_username_already_configured(normalized_username):
+                    return self.async_abort(reason="already_configured")
+
+                await self.async_set_unique_id(normalized_username)
                 self._abort_if_unique_id_configured()
 
                 # Validate the credentials here if possible
@@ -150,6 +152,16 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 raise InvalidAuth()
         finally:
             await client.close()
+
+    def _is_username_already_configured(self, normalized_username: str) -> bool:
+        """Check for existing entries that match username (legacy-safe)."""
+        for entry in self._async_current_entries():
+            configured_username = entry.data.get(CONF_USERNAME)
+            if not configured_username:
+                continue
+            if configured_username.strip().lower() == normalized_username:
+                return True
+        return False
 
 
 class CannotConnect(HomeAssistantError):

--- a/custom_components/tests/test_config_flow.py
+++ b/custom_components/tests/test_config_flow.py
@@ -76,3 +76,32 @@ async def test_user_step_aborts_when_account_already_configured(hass):
 
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"
+
+
+@pytest.mark.asyncio
+async def test_user_step_aborts_for_legacy_entry_without_unique_id(hass):
+    """Ensure duplicate accounts are blocked for pre-unique-id entries."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: "user@example.com", CONF_PASSWORD: "secret"},
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ail.config_flow.AILEnergyClient.login",
+        new=AsyncMock(return_value=True),
+    ), patch(
+        "custom_components.ail.config_flow.AILEnergyClient.close",
+        new=AsyncMock(),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": "user"},
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_USERNAME: "User@Example.com", CONF_PASSWORD: "secret"},
+        )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"

--- a/custom_components/tests/test_config_flow.py
+++ b/custom_components/tests/test_config_flow.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.ail.config_flow import ConfigFlow, InvalidAuth
 from custom_components.ail.const import CONF_PASSWORD, CONF_USERNAME, DOMAIN
@@ -45,3 +46,33 @@ async def test_test_credentials_closes_client_on_invalid_auth(hass):
                 {CONF_USERNAME: "user@example.com", CONF_PASSWORD: "wrong"}
             )
         close_client.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_user_step_aborts_when_account_already_configured(hass):
+    """Ensure duplicate accounts are blocked by unique ID."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="user@example.com",
+        data={CONF_USERNAME: "user@example.com", CONF_PASSWORD: "secret"},
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ail.config_flow.AILEnergyClient.login",
+        new=AsyncMock(return_value=True),
+    ), patch(
+        "custom_components.ail.config_flow.AILEnergyClient.close",
+        new=AsyncMock(),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": "user"},
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_USERNAME: "User@Example.com", CONF_PASSWORD: "secret"},
+        )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"


### PR DESCRIPTION
Summary
- normalize usernames during setup, set unique IDs, and reuse AbortFlow to stop duplicate account additions
- add backwards-compatible detection for legacy entries without unique IDs so they are also blocked
- cover the new behavior with config flow tests that exercise duplicate detection

Testing
- Not run (not requested)